### PR TITLE
Switch provider pattern to Regex plus template

### DIFF
--- a/SSMSVSExtensions.sln
+++ b/SSMSVSExtensions.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.32901.82
+# Visual Studio Version 17
+VisualStudioVersion = 17.4.33006.217
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SQLSynSugarAndValidation", "SQLSynSugarAndValidation\SQLSynSugarAndValidation.csproj", "{F14C5D20-D1C6-4830-B56E-5B6CAA329DA6}"
 EndProject
@@ -25,26 +25,9 @@ Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "SQLPasteShared", "SQLPasteS
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "StringProcessorShared", "StringProcessorShared\StringProcessorShared.shproj", "{0CD91EDB-9DF6-4D46-9CBB-1D7BF984A8C1}"
 EndProject
+Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "SourceControlDLSharedNoDep", "SourceControlDLShared2\SourceControlDLSharedNoDep.shproj", "{C5259345-0E97-4820-AADD-A4343B8D9F12}"
+EndProject
 Global
-	GlobalSection(SharedMSBuildProjectFiles) = preSolution
-		StringProcessorShared\StringProcessorShared.projitems*{0cd91edb-9df6-4d46-9cbb-1d7bf984a8c1}*SharedItemsImports = 13
-		SourceControlDLShared\SourceControlDLShared.projitems*{373dcc21-2ff6-40ca-8108-0dc646ca4553}*SharedItemsImports = 13
-		SQLPasteShared\SQLPasteShared.projitems*{373ec34a-f4a0-4cb3-80fb-26884bae0fb4}*SharedItemsImports = 13
-		SharedSrc\SharedSrc.projitems*{3c01a506-2c7d-4960-87c0-3cbac57bc1d5}*SharedItemsImports = 13
-		SharedSrc\SharedSrc.projitems*{4e7f8fb3-33ee-4284-87fe-e78ebddb1406}*SharedItemsImports = 4
-		SourceControlDLShared\SourceControlDLShared.projitems*{4e7f8fb3-33ee-4284-87fe-e78ebddb1406}*SharedItemsImports = 4
-		SharedSrc\SharedSrc.projitems*{5150b5ef-a45d-4413-88d4-74170633301d}*SharedItemsImports = 4
-		SQLPasteShared\SQLPasteShared.projitems*{5150b5ef-a45d-4413-88d4-74170633301d}*SharedItemsImports = 4
-		StringProcessorShared\StringProcessorShared.projitems*{5150b5ef-a45d-4413-88d4-74170633301d}*SharedItemsImports = 4
-		SharedSrc\SharedSrc.projitems*{6124e701-d127-43cc-a495-ee03614f427e}*SharedItemsImports = 4
-		SourceControlDLShared\SourceControlDLShared.projitems*{6124e701-d127-43cc-a495-ee03614f427e}*SharedItemsImports = 4
-		SharedSrc\SharedSrc.projitems*{d298403f-60cc-469c-8346-4d7fa4ee9ab4}*SharedItemsImports = 4
-		SharedSrc\SharedSrc.projitems*{e324ee0e-3065-4319-968d-301f51ac0578}*SharedItemsImports = 4
-		SQLPasteShared\SQLPasteShared.projitems*{e324ee0e-3065-4319-968d-301f51ac0578}*SharedItemsImports = 4
-		StringProcessorShared\StringProcessorShared.projitems*{e324ee0e-3065-4319-968d-301f51ac0578}*SharedItemsImports = 4
-		SharedSrc\SharedSrc.projitems*{f14c5d20-d1c6-4830-b56e-5b6caa329da6}*SharedItemsImports = 4
-		StringProcessorShared\StringProcessorShared.projitems*{f2661ed4-48f7-4f33-a69b-59893d7a9638}*SharedItemsImports = 5
-	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Debug|arm64 = Debug|arm64
@@ -144,5 +127,28 @@ Global
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {17B087D6-5836-44DE-99BD-91F74F461310}
+	EndGlobalSection
+	GlobalSection(SharedMSBuildProjectFiles) = preSolution
+		StringProcessorShared\StringProcessorShared.projitems*{0cd91edb-9df6-4d46-9cbb-1d7bf984a8c1}*SharedItemsImports = 13
+		SourceControlDLShared\SourceControlDLShared.projitems*{373dcc21-2ff6-40ca-8108-0dc646ca4553}*SharedItemsImports = 13
+		SQLPasteShared\SQLPasteShared.projitems*{373ec34a-f4a0-4cb3-80fb-26884bae0fb4}*SharedItemsImports = 13
+		SharedSrc\SharedSrc.projitems*{3c01a506-2c7d-4960-87c0-3cbac57bc1d5}*SharedItemsImports = 13
+		SharedSrc\SharedSrc.projitems*{4e7f8fb3-33ee-4284-87fe-e78ebddb1406}*SharedItemsImports = 4
+		SourceControlDLShared2\SourceControlDLShared2.projitems*{4e7f8fb3-33ee-4284-87fe-e78ebddb1406}*SharedItemsImports = 4
+		SourceControlDLShared\SourceControlDLShared.projitems*{4e7f8fb3-33ee-4284-87fe-e78ebddb1406}*SharedItemsImports = 4
+		SharedSrc\SharedSrc.projitems*{5150b5ef-a45d-4413-88d4-74170633301d}*SharedItemsImports = 4
+		SQLPasteShared\SQLPasteShared.projitems*{5150b5ef-a45d-4413-88d4-74170633301d}*SharedItemsImports = 4
+		StringProcessorShared\StringProcessorShared.projitems*{5150b5ef-a45d-4413-88d4-74170633301d}*SharedItemsImports = 4
+		SharedSrc\SharedSrc.projitems*{6124e701-d127-43cc-a495-ee03614f427e}*SharedItemsImports = 4
+		SourceControlDLShared2\SourceControlDLShared2.projitems*{6124e701-d127-43cc-a495-ee03614f427e}*SharedItemsImports = 4
+		SourceControlDLShared\SourceControlDLShared.projitems*{6124e701-d127-43cc-a495-ee03614f427e}*SharedItemsImports = 4
+		SourceControlDLShared2\SourceControlDLShared2.projitems*{c5259345-0e97-4820-aadd-a4343b8d9f12}*SharedItemsImports = 13
+		SharedSrc\SharedSrc.projitems*{d298403f-60cc-469c-8346-4d7fa4ee9ab4}*SharedItemsImports = 4
+		SharedSrc\SharedSrc.projitems*{e324ee0e-3065-4319-968d-301f51ac0578}*SharedItemsImports = 4
+		SQLPasteShared\SQLPasteShared.projitems*{e324ee0e-3065-4319-968d-301f51ac0578}*SharedItemsImports = 4
+		StringProcessorShared\StringProcessorShared.projitems*{e324ee0e-3065-4319-968d-301f51ac0578}*SharedItemsImports = 4
+		SharedSrc\SharedSrc.projitems*{f14c5d20-d1c6-4830-b56e-5b6caa329da6}*SharedItemsImports = 4
+		SourceControlDLShared2\SourceControlDLShared2.projitems*{f2661ed4-48f7-4f33-a69b-59893d7a9638}*SharedItemsImports = 5
+		StringProcessorShared\StringProcessorShared.projitems*{f2661ed4-48f7-4f33-a69b-59893d7a9638}*SharedItemsImports = 5
 	EndGlobalSection
 EndGlobal

--- a/SourceControlDLShared/Commands/BitbucketDeepLinkCommand.cs
+++ b/SourceControlDLShared/Commands/BitbucketDeepLinkCommand.cs
@@ -72,7 +72,7 @@ namespace SourceControlDeepLinks.Commands
 			var currentBranch = await gitHelper.GetCurrentBranchAsync( workingDirectory );
 
 			var bookmarkedLines = e.InValue as string;
-			var providerHelper = new ProviderHelper();
+			var providerHelper = new ProviderFactory();
 			var providerLinkInfo = providerHelper.GetDeepLink
 			(
 				provider,

--- a/SourceControlDLShared/Helpers/BitbucketProviderHelper.cs
+++ b/SourceControlDLShared/Helpers/BitbucketProviderHelper.cs
@@ -9,8 +9,8 @@ namespace SourceControlDeepLinks.Helpers
 	{
 		public static ProviderInfo GetDefault( AppSettingsHelper appSettingsHelper )
 		{
-			var originRegex = appSettingsHelper.GetString( "GithubOriginRegex" );
-			var sourceLinkTemplate = appSettingsHelper.GetString( "GithubSourceLinkTemplate" );
+			var originRegex = appSettingsHelper.GetString( "BitbuckerOriginRegex" );
+			var sourceLinkTemplate = appSettingsHelper.GetString( "BitbuckerSourceLinkTemplate" );
 
 			var pi = new ProviderInfo();
 			pi.Set( originRegex, sourceLinkTemplate, "", false );

--- a/SourceControlDLShared/Helpers/ProviderFactory.cs
+++ b/SourceControlDLShared/Helpers/ProviderFactory.cs
@@ -3,10 +3,10 @@ using SourceControlDeepLinks.Options;
 
 namespace SourceControlDeepLinks.Helpers
 {
-	public class ProviderHelper
+	public class ProviderFactory
 	{
 		AppSettingsHelper _appSettings;
-		public ProviderHelper()
+		public ProviderFactory()
 		{
 			_appSettings = new AppSettingsHelper();
 		}

--- a/SourceControlDLShared/Options/ProviderInfo.cs
+++ b/SourceControlDLShared/Options/ProviderInfo.cs
@@ -7,64 +7,94 @@ namespace SourceControlDeepLinks.Options
 	{
 		public ProviderInfo()
 		{
-			Domain = string.Empty;
-			BaseUrl = string.Empty;
-			ProjectPrefix = string.Empty;
+			OriginRegex = string.Empty;
+			SourceLinkTemplate = string.Empty;
 			DefaultBranch = string.Empty;
 			UseDefaultBranch = false;
 		}
 
 		public void Set
 		(
-			string domain,
-			string baseUrl,
-			string prefix,
+			string originRegex,
+			string sourceLinkTemplate,
 			string defaultBranch,
 			bool useDefaultBranch
 		)
 		{
-			Domain = domain;
-			BaseUrl = baseUrl;
-			ProjectPrefix = prefix;
+			OriginRegex = originRegex;
+			SourceLinkTemplate = sourceLinkTemplate;
 			DefaultBranch = defaultBranch;
 			UseDefaultBranch = useDefaultBranch;
 		}
 		public void Set( ProviderInfo from )
 		{
-			Domain = from.Domain;
-			BaseUrl = from.BaseUrl;
-			ProjectPrefix = from.ProjectPrefix;
+			OriginRegex = from.OriginRegex;
+			SourceLinkTemplate = from.SourceLinkTemplate;
 			DefaultBranch = from.DefaultBranch;
 			UseDefaultBranch = from.UseDefaultBranch;
 		}
 
 
-		public string Domain { get; private set; }
-		public string BaseUrl { get; private set; }
-		public string ProjectPrefix { get; private set; }
+		public string OriginRegex { get; private set; }
+		public string SourceLinkTemplate { get; private set; }
 		public string DefaultBranch { get; private set; }
 		public bool UseDefaultBranch { get; private set; }
 
+
 		public string Serialize(string key)
 		{
-			return $"{key};{Domain},{BaseUrl},{ProjectPrefix},{DefaultBranch},{UseDefaultBranch}";
+			// TODO: encode ',' to protect RegEx
+			return $"V1{key};{OriginRegex},{SourceLinkTemplate},{DefaultBranch},{UseDefaultBranch}";
 		}
-		public static ProviderInfo Deserialize( string s )
+		public static ProviderInfo Deserialize( char version, string s )
 		{
 			var pi = new ProviderInfo();
 			var fields = s.Split( new char[]{','}, StringSplitOptions.None );
+
+			if( version == '0' )
+			{
+				return Version0(pi, fields);
+			}
+			return Version1( pi, fields );
+
+		}
+
+		private static ProviderInfo Version1( ProviderInfo pi, string[] fields )
+		{
 			var l = fields.Length;
+
 			if( l > 0 )
 			{
-				pi.Domain = fields[ 0 ];
+				pi.OriginRegex = fields[0];
 			}
 			if( l > 1 )
 			{
-				pi.BaseUrl = fields[ 1 ];
+				pi.SourceLinkTemplate = fields[ 1 ];
 			}
 			if( l > 2 )
 			{
-				pi.ProjectPrefix = fields[ 2 ];
+				pi.DefaultBranch = fields[ 2 ];
+			}
+			if( l > 3 )
+			{
+				Boolean.TryParse( fields[ 3 ], out var b );
+				pi.UseDefaultBranch = b;
+			}
+			return pi;
+		}
+
+		private static ProviderInfo Version0( ProviderInfo pi, string[] fields )
+		{
+			var l = fields.Length;
+
+			if( l > 0 )
+			{
+			}
+			if( l > 1 )
+			{
+			}
+			if( l > 2 )
+			{
 			}
 			if( l > 3 )
 			{

--- a/SourceControlDLShared/SourceControlDLShared.projitems
+++ b/SourceControlDLShared/SourceControlDLShared.projitems
@@ -15,7 +15,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\BitbucketProviderHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\GitHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\GithubProviderHelper.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Helpers\ProviderHelper.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Helpers\ProviderFactory.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\ProviderLinkInfo.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\SettingsHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Options\ExtensionOptions.cs" />

--- a/SourceControlDLShared2/Helpers/ProviderHelper.cs
+++ b/SourceControlDLShared2/Helpers/ProviderHelper.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.RegularExpressions;
+
+
+namespace SourceControlDLSharedNoDep.Helpers
+{
+	public static class ProviderHelper
+	{
+		public static Dictionary<string, string> ResolveRegex
+		(
+			string originRegex,
+			string originUrl
+		)
+		{
+			var captures = new Dictionary<string, string>();
+			if( string.IsNullOrEmpty(originRegex) )
+			{
+				return captures;
+			}
+			var regex = new Regex( originRegex );
+
+			var match = regex.Match(originUrl);
+			if( match.Success )
+			{
+				var groups = match.Groups;
+
+				foreach( var groupName in regex.GetGroupNames() )
+				{
+					var group = groups[groupName];
+					if( group.Name.Length > 2 && group.Length > 2 )
+					{ 
+						captures.Add( groupName, group.Value );
+					}
+				}
+			}
+
+			return captures;
+		}
+
+		public static string TranslateUrl
+		(
+			string template,
+			string branch,
+			string filePathFragment,
+			string lines,
+			Dictionary<string, string> captures
+		)
+		{
+			int iSpace;
+			var startIndex = 0;
+			var sb = new StringBuilder( template.Length );
+			var space = ' ';
+
+			while( startIndex < template.Length )
+			{
+				iSpace = template.IndexOf( space, startIndex );
+				if( iSpace != -1 )
+				{
+					sb.Append( template.Substring( startIndex, iSpace - startIndex ) );
+
+					startIndex += iSpace - startIndex + 1;
+					var endIndex = template.IndexOf( space, startIndex );
+					if( endIndex == -1 )
+					{
+						endIndex = template.Length;
+					}
+
+					var substitution = template.Substring( iSpace + 1, endIndex - startIndex );
+
+					// From Code
+					if( substitution == "file" )
+					{
+						sb.Append( filePathFragment );
+					}
+					else if( substitution == "branch" )
+					{
+						sb.Append( branch );
+					}
+					// From Capture Group
+					else if( captures.TryGetValue( substitution, out var capture ) )
+					{
+						sb.Append( capture );
+					}
+
+					startIndex = endIndex + 1;
+				}
+				else
+				{
+					sb.Append( template.Substring( startIndex ) );
+					startIndex = template.Length;
+				}
+			}
+
+			return sb.ToString();
+		}
+	}
+}

--- a/SourceControlDLShared2/Helpers/ProviderHelper.cs
+++ b/SourceControlDLShared2/Helpers/ProviderHelper.cs
@@ -29,7 +29,7 @@ namespace SourceControlDLSharedNoDep.Helpers
 				foreach( var groupName in regex.GetGroupNames() )
 				{
 					var group = groups[groupName];
-					if( group.Name.Length > 2 && group.Length > 2 )
+					if( group.Name.Length > 2 && group.Value.Length > 0 )
 					{ 
 						captures.Add( groupName, group.Value );
 					}

--- a/SourceControlDLShared2/SourceControlDLShared2.projitems
+++ b/SourceControlDLShared2/SourceControlDLShared2.projitems
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <MSBuildAllProjects Condition="'$(MSBuildVersion)' == '' Or '$(MSBuildVersion)' &lt; '16.0'">$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+    <HasSharedItems>true</HasSharedItems>
+    <SharedGUID>c5259345-0e97-4820-aadd-a4343b8d9f12</SharedGUID>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration">
+    <Import_RootNamespace>SourceControlDLShared2</Import_RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)Helpers\ProviderHelper.cs" />
+  </ItemGroup>
+</Project>

--- a/SourceControlDLShared2/SourceControlDLSharedNoDep.shproj
+++ b/SourceControlDLShared2/SourceControlDLSharedNoDep.shproj
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>c5259345-0e97-4820-aadd-a4343b8d9f12</ProjectGuid>
+    <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
+  </PropertyGroup>
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.Default.props" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.props" />
+  <PropertyGroup />
+  <Import Project="SourceControlDLShared2.projitems" Label="Shared" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.CSharp.targets" />
+</Project>

--- a/SourceControlDeepLinks/App.config
+++ b/SourceControlDeepLinks/App.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <appSettings>
-    <add key="BitbuckerOriginRegex" value="^.*//code\.(?&lt;domain>[\w.]*)/scm/(?&lt;project>[\w].)/(?&lt;repo>[\w.]*)\.git"/>
-    <add key="GithubSourceLinkTemplate" value="https://code. domain /scm/ project /repos/ repo /browse/ file"/>
+    <add key="BitbuckerOriginRegex" value="^.*//code\.(?&lt;domain>[\w.]*)/scm/(?&lt;project>[\w]*)/(?&lt;repo>[\w.]*)\.git"/>
+    <add key="BitbuckerSourceLinkTemplate" value="https://code. domain /scm/ project /repos/ repo /browse/ file"/>
     <add key="GithubOriginRegex" value="^.*//github\.com/(?&lt;profile>[\w.]*)/(?&lt;repo>[\w-.]*)\.git"/>
     <add key="GithubSourceLinkTemplate" value="https://github.com/ profile / repo /blob/ branch / file"/>
     <add key="ClientSettingsProvider.ServiceUri" value="" />

--- a/SourceControlDeepLinks/App.config
+++ b/SourceControlDeepLinks/App.config
@@ -1,12 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <appSettings>
-    <add key="BitbucketDomain" value="YOUR_DOMAIN_HERE" />
-    <add key="BitbucketBase" value="https://code.{0}/projects" />
-    <add key="SCM" value="/scm/" />
-    <add key="GithubDomain" value="YOUR_PROFILE_HERE"/>
-    <add key="GithubBase" value="https://github.com/{0}"/>
-    <add key="GithubScm" value="blob"/>
+    <add key="BitbuckerOriginRegex" value="^.*//code\.(?&lt;domain>[\w.]*)/scm/(?&lt;project>[\w].)/(?&lt;repo>[\w.]*)\.git"/>
+    <add key="GithubSourceLinkTemplate" value="https://code. domain /scm/ project /repos/ repo /browse/ file"/>
+    <add key="GithubOriginRegex" value="^.*//github\.com/(?&lt;profile>[\w.]*)/(?&lt;repo>[\w-.]*)\.git"/>
+    <add key="GithubSourceLinkTemplate" value="https://github.com/ profile / repo /blob/ branch / file"/>
     <add key="ClientSettingsProvider.ServiceUri" value="" />
   </appSettings>
   <system.web>

--- a/SourceControlDeepLinks/SourceControlDeepLinks.csproj
+++ b/SourceControlDeepLinks/SourceControlDeepLinks.csproj
@@ -111,6 +111,7 @@
   </ItemGroup>
   <Import Project="..\SharedSrc\SharedSrc.projitems" Label="Shared" />
   <Import Project="..\SourceControlDLShared\SourceControlDLShared.projitems" Label="Shared" />
+  <Import Project="..\SourceControlDLShared2\SourceControlDLShared2.projitems" Label="Shared" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/SourceControlDeepLinks/source.extension.vsixmanifest
+++ b/SourceControlDeepLinks/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="SourceControlDeepLinks.1eab7686-ed75-494e-8a2d-cfd4d2da1477" Version="0.8.4" Language="en-US" Publisher="Jeff Lomax" />
+        <Identity Id="SourceControlDeepLinks.1eab7686-ed75-494e-8a2d-cfd4d2da1477" Version="0.8.5" Language="en-US" Publisher="Jeff Lomax" />
         <DisplayName>SourceControlDeepLinks</DisplayName>
         <Description xml:space="preserve">VSIX Source Control Extension for Bitbucket Server</Description>
         <Icon>Resources\Icon.png</Icon>

--- a/SourceControlDeepLinksVS2022/App.config
+++ b/SourceControlDeepLinksVS2022/App.config
@@ -1,12 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <appSettings>
-    <add key="BitbucketDomain" value="YOUR_DOMAIN_HERE" />
-    <add key="BitbucketBase" value="https://code.{0}/projects" />
-    <add key="SCM" value="/scm/" />
-    <add key="GithubDomain" value="YOUR_PROFILE_HERE"/>
-    <add key="GithubBase" value="https://github.com/{0}"/>
-    <add key="GithubScm" value="blob"/>
+    <add key="BitbuckerOriginRegex" value="^.*//code\.(?&lt;domain>[\w.]*)/scm/(?&lt;project>[\w].)/(?&lt;repo>[\w.]*)\.git"/>
+    <add key="GithubSourceLinkTemplate" value="https://code. domain /scm/ project /repos/ repo /browse/ file"/>    
+    <add key="GithubOriginRegex" value="^.*//github\.com/(?&lt;profile>[\w.]*)/(?&lt;repo>[\w-.]*)\.git"/>
+    <add key="GithubSourceLinkTemplate" value="https://github.com/ profile / repo /blob/ branch / file"/>
     <add key="ClientSettingsProvider.ServiceUri" value="" />
   </appSettings>
   <system.web>

--- a/SourceControlDeepLinksVS2022/App.config
+++ b/SourceControlDeepLinksVS2022/App.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <appSettings>
-    <add key="BitbuckerOriginRegex" value="^.*//code\.(?&lt;domain>[\w.]*)/scm/(?&lt;project>[\w].)/(?&lt;repo>[\w.]*)\.git"/>
-    <add key="GithubSourceLinkTemplate" value="https://code. domain /scm/ project /repos/ repo /browse/ file"/>    
+    <add key="BitbuckerOriginRegex" value="^.*//code\.(?&lt;domain>[\w.]*)/scm/(?&lt;project>[\w]*)/(?&lt;repo>[\w.]*)\.git"/>
+    <add key="BitbuckerSourceLinkTemplate" value="https://code. domain /scm/ project /repos/ repo /browse/ file"/>    
     <add key="GithubOriginRegex" value="^.*//github\.com/(?&lt;profile>[\w.]*)/(?&lt;repo>[\w-.]*)\.git"/>
     <add key="GithubSourceLinkTemplate" value="https://github.com/ profile / repo /blob/ branch / file"/>
     <add key="ClientSettingsProvider.ServiceUri" value="" />

--- a/SourceControlDeepLinksVS2022/SourceControlDeepLinksVS2022.csproj
+++ b/SourceControlDeepLinksVS2022/SourceControlDeepLinksVS2022.csproj
@@ -107,6 +107,7 @@
   </ItemGroup>
   <Import Project="..\SharedSrc\SharedSrc.projitems" Label="Shared" />
   <Import Project="..\SourceControlDLShared\SourceControlDLShared.projitems" Label="Shared" />
+  <Import Project="..\SourceControlDLShared2\SourceControlDLShared2.projitems" Label="Shared" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/SourceControlDeepLinksVS2022/source.extension.vsixmanifest
+++ b/SourceControlDeepLinksVS2022/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="SourceControlDeepLinks.ea8550af-3db2-42ff-87f0-49af5d25b409" Version="1.3" Language="en-US" Publisher="Jeff Lomax" />
+        <Identity Id="SourceControlDeepLinks.ea8550af-3db2-42ff-87f0-49af5d25b409" Version="1.6" Language="en-US" Publisher="Jeff Lomax" />
         <DisplayName>SourceControlDeepLinksV2</DisplayName>
         <Description xml:space="preserve">Source Control Deep Links for VS 2022
 </Description>

--- a/UnitTests/GitTests.cs
+++ b/UnitTests/GitTests.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if false
+using System;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using SourceControlDeepLinks.Helpers;
@@ -30,3 +31,4 @@ namespace UnitTests
 		}
 	}
 }
+#endif

--- a/UnitTests/ProviderTests.cs
+++ b/UnitTests/ProviderTests.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using SourceControlDLSharedNoDep.Helpers;
+
+namespace UnitTests
+{
+	public class ProviderTests
+	{
+		[SetUp]
+		public void Setup()
+		{
+		}
+
+		[Test]
+		public void TranslateUrlGit()
+		{
+			// From App.Config
+			var originRegex = @"^.*//github\.com/(?<profile>[\w.]*)/(?<repo>[\w-.]*)\.git";
+			// from .git/config [remote "origin"]
+			var originUrl = @"https://github.com/jefflomax/ssms-vs-extensions.git";
+
+			var template = @"https://github.com/ profile / repo /blob/ branch / file";
+			var branch = "main";
+			var filePathFragment = @"SourceControlDeepLinksVS2022/VSCommandTable.cs";
+			var lines = "";
+
+			var captures = ProviderHelper.ResolveRegex( originRegex, originUrl );
+
+			Assert.AreEqual( 2, captures.Count );
+			var expectedCaptures = new Dictionary<string, string>
+			{
+				["profile"] = "jefflomax",
+				["repo"] = "ssms-vs-extensions"
+			};
+			Assert.That(captures, Is.EqualTo(expectedCaptures));
+
+			var translatedUrl = ProviderHelper.TranslateUrl
+			(
+				template,
+				branch,
+				filePathFragment,
+				lines,
+				captures
+			);
+
+			var expected = @"https://github.com/jefflomax/ssms-vs-extensions/blob/main/SourceControlDeepLinksVS2022/VSCommandTable.cs";
+
+			Assert.AreEqual( expected, translatedUrl );
+		}
+	}
+}

--- a/UnitTests/ProviderTests.cs
+++ b/UnitTests/ProviderTests.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Threading.Tasks;
 using NUnit.Framework;
 using SourceControlDLSharedNoDep.Helpers;
 
@@ -14,7 +13,7 @@ namespace UnitTests
 		}
 
 		[Test]
-		public void TranslateUrlGit()
+		public void TranslateUrlGithub()
 		{
 			// From App.Config
 			var originRegex = @"^.*//github\.com/(?<profile>[\w.]*)/(?<repo>[\w-.]*)\.git";
@@ -31,10 +30,10 @@ namespace UnitTests
 			Assert.AreEqual( 2, captures.Count );
 			var expectedCaptures = new Dictionary<string, string>
 			{
-				["profile"] = "jefflomax",
-				["repo"] = "ssms-vs-extensions"
+				[ "profile" ] = "jefflomax",
+				[ "repo" ] = "ssms-vs-extensions"
 			};
-			Assert.That(captures, Is.EqualTo(expectedCaptures));
+			Assert.That( captures, Is.EqualTo( expectedCaptures ) );
 
 			var translatedUrl = ProviderHelper.TranslateUrl
 			(
@@ -48,6 +47,45 @@ namespace UnitTests
 			var expected = @"https://github.com/jefflomax/ssms-vs-extensions/blob/main/SourceControlDeepLinksVS2022/VSCommandTable.cs";
 
 			Assert.AreEqual( expected, translatedUrl );
+		}
+
+		[Test]
+		public void TranslateUrlBitbucketServer()
+		{
+			// From App.Config
+			var originRegex = @"^.*//code\.(?<domain>[\w.]*)/scm/(?<project>[\w]*)/(?<repo>[\w.]*)\.git";
+			// from .git/config [remote "origin"]
+			var originUrl = @"https://code.yourdomain.com/scm/TC/yourdomain.yourrepo.git";
+
+			var template = @"https://code. domain /scm/ project /repos/ repo /browse/ file";
+			var branch = "";
+			var filePathFragment = @"TestFolder/Test.cs";
+			var lines = "";
+
+			var captures = ProviderHelper.ResolveRegex( originRegex, originUrl );
+
+			Assert.AreEqual( 3, captures.Count );
+			var expectedCaptures = new Dictionary<string, string>
+			{
+				[ "domain" ] = "yourdomain.com",
+				[ "project" ] = "TC",
+				[ "repo" ] = "yourdomain.yourrepo"
+			};
+			Assert.That( captures, Is.EqualTo( expectedCaptures ) );
+
+			var translatedUrl = ProviderHelper.TranslateUrl
+			(
+				template,
+				branch,
+				filePathFragment,
+				lines,
+				captures
+			);
+
+			var expected = @"https://code.yourdomain.com/scm/TC/repos/yourdomain.yourrepo/browse/TestFolder/Test.cs";
+
+			Assert.AreEqual( expected, translatedUrl );
+
 		}
 	}
 }

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -6,6 +6,14 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <NoWarn>1701;1702,NU1701</NoWarn>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <NoWarn>1701;1702,NU1701</NoWarn>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
     <PackageReference Include="NUnit" Version="3.13.3" />
@@ -17,10 +25,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\SourceControlDeepLinks\SourceControlDeepLinks.csproj" />
     <ProjectReference Include="..\SQLSynSugarAndValidation\SQLSynSugarAndValidation.csproj" />
   </ItemGroup>
 
   <Import Project="..\StringProcessorShared\StringProcessorShared.projitems" Label="Shared" />
+
+  <Import Project="..\SourceControlDLShared2\SourceControlDLShared2.projitems" Label="Shared" />
 
 </Project>


### PR DESCRIPTION
Providers now have a regex with named capture groups to extract things like profile, domain, repository, etc. from the origin URL.  The capture groups along with inbuilt "file" and "branch" are applied to a URL template, space delimited.